### PR TITLE
Latest access changes

### DIFF
--- a/ansible-weblogic12c/linux/infra-vars.yml
+++ b/ansible-weblogic12c/linux/infra-vars.yml
@@ -15,21 +15,19 @@ mw_installer: 'fmw_12.2.1.2.0_wls.jar'
 domain_name: 'custom_domain'
 
 # Nodemanager and server settings
-#node_manager_address: '192.168.56.14'
-node_manager_address: '127.0.0.1'
-# Nedastående används ej
-node_manager_hostname: '192.168.56.14'
+node_manager_address: '192.168.56.14'
+node_manager_hostname: 'wls12c-r2-1.private'
 node_manager_port: '5556'
 # Pga problem med SSL så ändrade jag till "plain".
 node_manager_type: 'plain'
 #
 admin_server_address: '192.168.56.14'
-admin_server_hostname: '192.168.56.14'
+admin_server_hostname: 'wls12c-r2-1.private'
 admin_server_name: 'AdminServer'
 admin_server_port: '7001'
 #
 managed_server_hostname: '192.168.56.14'
-managed_server_address: '192.168.56.14'
+managed_server_address: 'wls12c-r2-1.private'
 managed_server_name: 'managed_1'
 managed_server_port: '8001'
 #

--- a/ansible-weblogic12c/linux/infra-vars.yml
+++ b/ansible-weblogic12c/linux/infra-vars.yml
@@ -26,8 +26,8 @@ admin_server_hostname: 'wls12c-r2-1.private'
 admin_server_name: 'AdminServer'
 admin_server_port: '7001'
 #
-managed_server_hostname: '192.168.56.14'
-managed_server_address: 'wls12c-r2-1.private'
+managed_server_address: '192.168.56.14'
+managed_server_hostname: 'wls12c-r2-1.private'
 managed_server_name: 'managed_1'
 managed_server_port: '8001'
 #

--- a/ansible-weblogic12c/linux/roles/create-domain/templates/create-domain.py
+++ b/ansible-weblogic12c/linux/roles/create-domain/templates/create-domain.py
@@ -40,7 +40,7 @@ cd('/Server/' + '{{ admin_server_name }}');
 cmo.setListenPort({{ admin_server_port }});
 cmo.setListenAddress('{{ admin_server_address }}');
 
-try: cmo.setMachine(getMBean('/Machines/' + '{{ admin_server_address }}'))
+try: cmo.setMachine(getMBean('/Machines/' + '{{ admin_server_hostname }}'))
 except Exception:
     print "setMachine failed"
 

--- a/ansible-weblogic12c/linux/roles/create-managed-server/templates/create-managed.py
+++ b/ansible-weblogic12c/linux/roles/create-managed-server/templates/create-managed.py
@@ -7,25 +7,26 @@ startEdit();
 # applyJRF(target='{{ managed_server_name }}', domainDir='{{ domain_home }}');
 cd('/')
 
-try: cmo.createMachine('{{ managed_server_address }}')
+try: cmo.createMachine('{{ managed_server_hostname }}')
 except Exception:
-    print "Machine already exists"
+    print "Machine {{ managed_server_hostname }} already exists"
 
-cd('/Machines/' + '{{ managed_server_address }}' + '/NodeManager/' + '{{ managed_server_address }}')
+cd('/Machines/' + '{{ managed_server_hostname }}' + '/NodeManager/' + '{{ managed_server_hostname }}')
 cmo.setListenAddress('{{ node_manager_address }}')
-
-
 cmo.setListenPort({{ node_manager_port }})
 cmo.setNMType('{{ node_manager_type }}')
 
 cd('/')
-cmo.createServer('{{ managed_server_name }}')
+
+try: cmo.createServer('{{ managed_server_name }}')
+except Exception:
+    print "Server {{ managed_server_name }} already exists"
 
 cd('/Servers/' + '{{ managed_server_name }}')
 cmo.setListenAddress('{{ managed_server_address }}')
 cmo.setListenPort({{ managed_server_port }})
 cmo.setListenPortEnabled(true);
-cmo.setMachine(getMBean('/Machines/' + '{{ managed_server_address }}'))
+cmo.setMachine(getMBean('/Machines/' + '{{ managed_server_hostname }}'))
 cmo.setCluster(None);
 cd('/Servers/' + '{{ managed_server_name }}' + '/SSL/' + '{{ managed_server_name }}')
 cmo.setEnabled(false)
@@ -38,7 +39,7 @@ cd('/')
 cd('/Servers/' + '{{ admin_server_name }}')
 #####cmo.setListenAddress('{{ admin_server_address }}')
 #####cmo.setListenPort({{ admin_server_port }})
-cmo.setMachine(getMBean('/Machines/' + '{{ admin_server_address }}'))
+cmo.setMachine(getMBean('/Machines/' + '{{ admin_server_hostname }}'))
 
 # applyJRF(target='{{ managed_server_name }}', domainDir='{{ domain_home }}');
 

--- a/ansible-weblogic12c/linux/roles/setup-nodemanager/tasks/main.yml
+++ b/ansible-weblogic12c/linux/roles/setup-nodemanager/tasks/main.yml
@@ -14,6 +14,26 @@
 #####  tags:
 #####    - start-nodemanager
 #####
+
+- name: Change the ListenAddress to be in line whith our configuration.
+  lineinfile:
+    dest: "{{ domain_home }}/nodemanager/nodemanager.properties"
+    regexp: "^ListenAddress="
+    line: "ListenAddress={{ node_manager_hostname }}"
+
+- name: Change the ListenPort to be in line whith our configuration.
+  lineinfile:
+    dest: "{{ domain_home }}/nodemanager/nodemanager.properties"
+    regexp: "^ListenPort="
+    line: "ListenPort={{ node_manager_port }}"
+
+- name: Change the NMType to be in line whith our configuration.
+  lineinfile:
+    dest: "{{ domain_home }}/nodemanager/nodemanager.properties"
+    regexp: "^ListenPort="
+    insertafter: "^ListenPort="
+    line: "NMType={{ node_manager_type }}"
+
 - name: Fetch files
   fetch:
    src: "{{ domain_home }}/nodemanager/nodemanager.properties"


### PR DESCRIPTION
Ändrat hostnamn och ip-address, verkar möjligen gå lite bättre. Verkar i alla fall som om det görs startförsöka av AdminServer och managed_1.


Apr 06 11:29:30 wls12c-r2-1.private startNodeManager.sh[16185]: coherence.startup.JavaHome=/oracle/fmw12.2.1/jdk1.8.0_161
Apr 06 11:29:30 wls12c-r2-1.private startNodeManager.sh[16185]: coherence.startup.MW_Home=
Apr 06 11:29:30 wls12c-r2-1.private startNodeManager.sh[16185]: Domain name mappings:
Apr 06 11:29:30 wls12c-r2-1.private startNodeManager.sh[16185]: custom_domain -> /oracle/fmw12.2.1/config/Domains/custom_domain
Apr 06 11:29:30 wls12c-r2-1.private startNodeManager.sh[16185]: <Apr 6, 2018 11:29:30 AM UTC> <INFO> <12.2.1.2.0>
Apr 06 11:29:30 wls12c-r2-1.private startNodeManager.sh[16185]: <Apr 6, 2018 11:29:30 AM UTC> <INFO> <custom_domain> <AdminServer> <Startup configuration properties loaded from "/oracle/fmw12.2.1/config/Domains/custom_domain/servers/AdminServer/data/nodemanager/startup.properties">
Apr 06 11:29:30 wls12c-r2-1.private startNodeManager.sh[16185]: <Apr 6, 2018 11:29:30 AM UTC> <INFO> <custom_domain> <AdminServer> <Adjusted state of server 'AdminServer ' from STARTING to FAILED_NOT_RESTARTABLE>
Apr 06 11:29:30 wls12c-r2-1.private startNodeManager.sh[16185]: <Apr 6, 2018 11:29:30 AM UTC> <INFO> <custom_domain> <managed_1> <Startup configuration properties loaded from "/oracle/fmw12.2.1/config/Domains/custom_domain/servers/managed_1/data/nodemanager/startup.properties">
Apr 06 11:29:30 wls12c-r2-1.private startNodeManager.sh[16185]: <Apr 6, 2018 11:29:30 AM UTC> <INFO> <custom_domain> <managed_1> <Adjusted state of server 'managed_1 ' from STARTING to FAILED_NOT_RESTARTABLE>
Apr 06 11:29:31 wls12c-r2-1.private startNodeManager.sh[16185]: <Apr 6, 2018 11:29:31 AM UTC> <INFO> <Secure socket listener started on port 5556, host wls12c-r2-1.private/192.168.56.14>